### PR TITLE
Eliminar psycopg2 de los requerimientos

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 Django==3.2.6
-psycopg2==2.9.1
 sqlparse==0.4.1


### PR DESCRIPTION
Como no usaremos mas postgresql eliminamos la librería de conexión con nuestro proyecto   